### PR TITLE
added devcontainer support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,5 @@
+FROM mcr.microsoft.com/devcontainers/java:11-bullseye
+
+RUN bash -c "bash < <(curl -s https://raw.githubusercontent.com/babashka/babashka/master/install)"
+RUN bash -c "bash < <(curl -s https://raw.githubusercontent.com/clojure-lsp/clojure-lsp/master/install)"
+RUN wget https://github.com/quarto-dev/quarto-cli/releases/download/v1.4.549/quarto-1.4.549-linux-amd64.deb && dpkg -i quarto-1.4.549-linux-amd64.deb

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+{
+	"name": "my Clojure app",
+	"build": {
+		"dockerfile": "Dockerfile"
+
+		},
+
+
+    "features": {
+	    	"ghcr.io/devcontainers-contrib/features/clojure-asdf:2": {},
+	    	"ghcr.io/devcontainers-contrib/features/tmux-apt-get:1": {},
+		"ghcr.io/devcontainers-contrib/features/bash-command:1": {"command": "apt-get update && apt-get install -y rlwrap"},
+		"ghcr.io/devcontainers-contrib/features/poetry:2" : {},
+		"ghcr.io/rocker-org/devcontainer-features/r-apt:0": {}
+
+
+},
+    "forwardPorts": ["12345","7777"],
+	"customizations": {
+		"vscode": {
+			"settings": { 
+			},
+			"extensions": 
+			[
+				"vscjava.vscode-java-pack",
+				"borkdude.clj-kondo",
+				"betterthantomorrow.calva"
+			]
+		}
+	},
+
+	"remoteUser": "vscode",
+	//"postStartCommand": "tmux new -d /home/vscode/.asdf/shims/clojure -Sdeps '{:deps {nrepl/nrepl {:mvn/version,\"1.0.0\"},cider/cider-nrepl {:mvn/version,\"RELEASE\"}}},refactor-nrepl/refactor-nrepl {:mvn/version \"RELEASE\"}}' -m nrepl.cmdline -p 12345 --middleware \"[cider.nrepl/cider-middleware]\" &"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[tool.poetry]
+name = "poetry"
+authors = ["Carsten Behring"]
+description = ""
+version = "0.0.0"
+
+[tool.poetry.dependencies]
+python = ">=3.9"
+matplotlib = "3.8.2"
+seaborn = "0.13.2"
+arviz = "0.17.0"


### PR DESCRIPTION
It took me longer to setup the document build then to write the new docu.

using a devcontainer supporting tool (vscode or devpod), it takes a single command (inside the devcontainer) to build the docs:

```
poetry update && poetry run clj -A:dev notebooks/dev.clj
```
