### PR TITLE
added libxtst to devcontainer setup (to support BufferedImage)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
 	   	"ghcr.io/devcontainers-contrib/features/clojure-asdf:2": {},
 		"ghcr.io/rocker-org/devcontainer-features/quarto-cli:1": {},
 		"ghcr.io/devcontainers-contrib/features/bash-command:1": 
-		    {"command": "apt-get update && apt-get install -y rlwrap"},
+		    {"command": "apt-get update && apt-get install -y rlwrap && apt-get install -y libxtst-dev"},
 		"ghcr.io/devcontainers-contrib/features/poetry:2" : {},
 		"ghcr.io/rocker-org/devcontainer-features/r-apt:0": {}
 


### PR DESCRIPTION
Adding [libxtst](https://gitlab.freedesktop.org/xorg/lib/libxtst), that seems to be needed for `tech.v3.libs.buffered-image` to work.

Without it, we get the following under the devcontainer:
```clj
Clojure 1.12.0
user=> (require 'tech.v3.libs.buffered-image)
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
Execution error (UnsatisfiedLinkError) at jdk.internal.loader.NativeLibraries/load (NativeLibraries.java:-2).
/usr/lib/jvm/msopenjdk-current/lib/libawt_xawt.so: libXtst.so.6: cannot open shared object file: No such file or directory
```

Zulip: https://clojurians.zulipchat.com/#narrow/channel/321125-noj-dev/topic/tech.2Ev3.2Elibs.2Ebuffered-image.20problem