### PR TITLE
reference chapters - added clarifications and removed the draft note

### DIFF
--- a/notebooks/noj_book/automl.clj
+++ b/notebooks/noj_book/automl.clj
@@ -266,8 +266,10 @@ ctx-after-train
 ;;  and nothing else changes, for example drop columns.
 
 ;; While most metamorph compliant operations behave the same in  
-;; :fit and :transform, there are some which do behave differently.
-;; They have a certain notion of "fit" and "transform".
+;; `:fit` and `:transform`, there are some which do behave differently.
+;; They have a certain notion of "fit" and "transform",
+;; that determines the way their behavior changse between these
+;; two modes.
 ;;
 ;; They are therefore called "transformer" and are listed in the 
 ;; "Transformer reference" 

--- a/notebooks/noj_book/sklearn_reference.clj
+++ b/notebooks/noj_book/sklearn_reference.clj
@@ -1,4 +1,12 @@
-;; # Sklearn model reference - DRAFT 🛠
+;; # Sklearn model reference
+
+;; As discussed in the [Machine Learning](../noj_book.ml_basic.html) chapter,
+;; this book contains reference chapters for machine learning models
+;; that can be registered in [metamorph.ml](https://github.com/scicloj/metamorph.ml).
+
+;; This specific chapter focuses on the models of the
+;; [scijit-learn](https://scikit-learn.org/stable/) Python library,
+;; which is wrapped by [sklearn-clj](https://github.com/scicloj/sklearn-clj).
 
 (ns noj-book.sklearn-reference
   (:require
@@ -23,7 +31,7 @@
 ;; But the translation between the two should be obvious.
 
 
-;;Example: [logistic regression](https://en.wikipedia.org/wiki/Logistic_regression)
+;; Example: [logistic regression](https://en.wikipedia.org/wiki/Logistic_regression)
 
 (def ds (dst/tensor->dataset [[0 0 0] [1 1 1] [2 2 2]]))
 

--- a/notebooks/noj_book/smile_classification.clj
+++ b/notebooks/noj_book/smile_classification.clj
@@ -1,4 +1,13 @@
-;; # Smile classification models reference - DRAFT 🛠
+;; # Smile classification models reference
+
+;; As discussed in the [Machine Learning](../noj_book.ml_basic.html) chapter,
+;; this book contains reference chapters for machine learning models
+;; that can be registered in [metamorph.ml](https://github.com/scicloj/metamorph.ml).
+
+;; This specific chapter focuses on classification models of
+;; [Smile](https://haifengl.github.io/) version 2.6,
+;; which are wrapped by
+;; [scicloj.ml.smile](https://github.com/scicloj/scicloj.ml.smile).
 
 ;; Note that this chapter reqiures `scicloj.ml.smile` as an additional
 ;; dependency to Noj.

--- a/notebooks/noj_book/smile_others.clj
+++ b/notebooks/noj_book/smile_others.clj
@@ -1,4 +1,14 @@
-;; # Smile other models reference - DRAFT 🛠
+;; # Smile other models reference
+
+;; As discussed in the [Machine Learning](../noj_book.ml_basic.html) chapter,
+;; this book contains reference chapters for machine learning models
+;; that can be registered in [metamorph.ml](https://github.com/scicloj/metamorph.ml).
+
+;; This specific chapter focuses on model-like algorithms
+;; such as clustering and dimension-reduction in
+;; [Smile](https://haifengl.github.io/) version 2.6,
+;; which are wrapped by
+;; [scicloj.ml.smile](https://github.com/scicloj/scicloj.ml.smile).
 
 ;; Note that this chapter reqiures `scicloj.ml.smile` as an additional
 ;; dependency to Noj.

--- a/notebooks/noj_book/smile_regression.clj
+++ b/notebooks/noj_book/smile_regression.clj
@@ -1,4 +1,13 @@
-;; # Smile regression models reference - DRAFT 🛠
+;; # Smile regression models reference
+
+;; As discussed in the [Machine Learning](../noj_book.ml_basic.html) chapter,
+;; this book contains reference chapters for machine learning models
+;; that can be registered in [metamorph.ml](https://github.com/scicloj/metamorph.ml).
+
+;; This specific chapter focuses on regression models of
+;; [Smile](https://haifengl.github.io/) version 2.6,
+;; which are wrapped by
+;; [scicloj.ml.smile](https://github.com/scicloj/scicloj.ml.smile).
 
 ;; Note that this chapter reqiures `scicloj.ml.smile` as an additional
 ;; dependency to Noj.

--- a/notebooks/noj_book/transformer_references.clj
+++ b/notebooks/noj_book/transformer_references.clj
@@ -1,9 +1,16 @@
-;; # Transformer reference  - DRAFT 🛠
+;; # Transformer reference
+
+;; As discussed in the [AutoML](../noj_book.automl.html) chapter,
+;; [metamorph.ml](https://github.com/scicloj/metamorph.ml) can have
+;; certain pipeline operations whose behavior changes
+;; between the `:fit` and `:transform` modes.
+;; These operations are called *transformers*.
+
+;; This chapter provides a reference for the currently existing transformers.
 
 ;; Note that this chapter reqiures `scicloj.ml.smile` as an additional
 ;; dependency to Noj.
 ;; [![Clojars Project](https://img.shields.io/clojars/v/org.scicloj/scicloj.ml.smile.svg)](https://clojars.org/org.scicloj/scicloj.ml.smile)
-
 
 (ns noj-book.transformer-references
   (:require

--- a/notebooks/noj_book/tribuo_reference.clj
+++ b/notebooks/noj_book/tribuo_reference.clj
@@ -1,4 +1,12 @@
-;; # Tribuo reference - DRAFT 🛠
+;; # Tribuo reference
+
+;; As discussed in the [Machine Learning](../noj_book.ml_basic.html) chapter,
+;; this book contains reference chapters for machine learning models
+;; that can be registered in [metamorph.ml](https://github.com/scicloj/metamorph.ml).
+
+;; This specific chapter focuses on the models of the
+;; [Tribuo](https://tribuo.org/) Java library,
+;; which is wrapped by [scicloj.ml.tribuo](https://github.com/scicloj/scicloj.ml.tribuo).
 
 ^:kindly/hide-code
 (ns noj-book.tribuo-reference

--- a/notebooks/noj_book/xgboost.clj
+++ b/notebooks/noj_book/xgboost.clj
@@ -1,4 +1,11 @@
-;; # Xgboost model reference - DRAFT 🛠
+;; # Xgboost model reference
+
+;; As discussed in the [Machine Learning](../noj_book.ml_basic.html) chapter,
+;; this book contains reference chapters for machine learning models
+;; that can be registered in [metamorph.ml](https://github.com/scicloj/metamorph.ml).
+
+;; This specific chapter focuses on the [XGBoost](https://en.wikipedia.org/wiki/XGBoost)
+;; algorithm provided by [scicloj.ml.xgboost](https://github.com/scicloj/scicloj.ml.xgboost).
 
 ^:kindly/hide-code
 (ns noj-book.xgboost


### PR DESCRIPTION
@behrica 

This PR:
* Adds some clarifications to the ml reference chapters -- basically, a few paragraphs at the top of each chapter that explains what it is about.
* Removed the draft notes from these chapters.

Does it look ok?