### PR TITLE
Simplifying data dependencies

### DIFF
--- a/data/chicago-bikes/README.md
+++ b/data/chicago-bikes/README.md
@@ -1,1 +1,0 @@
-source: [Cyclistic Bike Share 2023](https://www.kaggle.com/datasets/godofoutcasts/cyclistic-bike-share-2023)

--- a/deps.edn
+++ b/deps.edn
@@ -7,8 +7,7 @@
         generateme/fastmath                       {:mvn/version "3.0.0-alpha3"}
         aerial.hanami/aerial.hanami               {:mvn/version "0.20.1"}
         org.scicloj/tableplot                     {:mvn/version "1-beta10.1"}
-        org.scicloj/metamorph.ml                  {:git/url "https://github.com/scicloj/metamorph.ml.git"
-                                                   :sha "57ebb355eb3df5d020cd7d162c1fccd110394c2c"}
+        org.scicloj/metamorph.ml                  {:mvn/version "1.1.1"}
         org.scicloj/sklearn-clj                   {:mvn/version "0.5"}
         org.scicloj/scicloj.ml.xgboost            {:mvn/version "6.3.0"}
         

--- a/deps.edn
+++ b/deps.edn
@@ -7,7 +7,8 @@
         generateme/fastmath                       {:mvn/version "3.0.0-alpha3"}
         aerial.hanami/aerial.hanami               {:mvn/version "0.20.1"}
         org.scicloj/tableplot                     {:mvn/version "1-beta10.1"}
-        org.scicloj/metamorph.ml                  {:mvn/version "1.0"}
+        org.scicloj/metamorph.ml                  {:git/url "https://github.com/scicloj/metamorph.ml.git"
+                                                   :sha "57ebb355eb3df5d020cd7d162c1fccd110394c2c"}
         org.scicloj/sklearn-clj                   {:mvn/version "0.5"}
         org.scicloj/scicloj.ml.xgboost            {:mvn/version "6.3.0"}
         
@@ -90,11 +91,11 @@
 
                             {:git/url "https://github.com/clojupyter/clojupyter"
                              :git/sha "0f8ad0ca08a52eca32824035b9b6da28a724dd74"}
-                            ;{:git/url "https://github.com/behrica/clojupyter"
-                            ;:git/sha "15807a1842a34762d4dd683e9694f01f3fc2192f"}
+                                        ;{:git/url "https://github.com/behrica/clojupyter"
+                                        ;:git/sha "15807a1842a34762d4dd683e9694f01f3fc2192f"}
+                            
+                            }
                
-               }
                
-               
-                            ;{:mvn/version "0.4.332"}
+                                        ;{:mvn/version "0.4.332"}
                }}}

--- a/notebooks/noj_book/chicago_bike_times.clj
+++ b/notebooks/noj_book/chicago_bike_times.clj
@@ -36,7 +36,7 @@
 ;; You may learn more about the [Cyclistic Bike Share 2023](https://www.kaggle.com/datasets/godofoutcasts/cyclistic-bike-share-2023) dataset in our [Chicago bike trips](https://scicloj.github.io/clojure-data-scrapbook/projects/geography/chicago-bikes/index.html) tutorial.
 
 (defonce raw-trips
-  (-> "data/chicago-bikes/202304_divvy_tripdata.csv.gz"
+  (-> "https://divvy-tripdata.s3.amazonaws.com/202304-divvy-tripdata.zip"
       (tc/dataset {:key-fn keyword
                    :parser-fn {"started_at"
                                [:local-date-time

--- a/notebooks/noj_book/datasets.clj
+++ b/notebooks/noj_book/datasets.clj
@@ -2,52 +2,36 @@
 
 ;; author: Daniel Slutsky, Ken Huang
 
-;; ## Rdatasets
-;; For our tutorials here,
-;; let us fetch some datasets from [Rdatasets](https://vincentarelbundock.github.io/Rdatasets/):
+;; We may use various sources of datasets for our tutorials here.
 
 (ns noj-book.datasets
-  (:require [tablecloth.api :as tc]))
+  (:require [tablecloth.api :as tc]
+            [scicloj.metamorph.ml.rdatasets :as rdatasets]))
 
-(def iris
-  (-> "https://vincentarelbundock.github.io/Rdatasets/csv/datasets/iris.csv"
-      (tc/dataset {:key-fn keyword})
-      (tc/rename-columns {:Sepal.Length :sepal-length
-                          :Sepal.Width :sepal-width
-                          :Petal.Length :petal-length
-                          :Petal.Width :petal-width
-                          :Species :species})))
+;; ## rdatasets
+;; One of the main sources is the `rdatasets` namespace of [metamorph.ml](https://github.com/scicloj/metamorph.ml),
+;; which can fetch datasets from the [Rdatasets](https://vincentarelbundock.github.io/Rdatasets/) collection.
 
-iris
+(rdatasets/datasets-iris)
 
-(def mtcars
-  (-> "https://vincentarelbundock.github.io/Rdatasets/csv/datasets/mtcars.csv"
-      (tc/dataset {:key-fn keyword})))
+(rdatasets/ggplot2-mpg)
 
-mtcars
-
-(def scatter
-  (-> "https://vincentarelbundock.github.io/Rdatasets/csv/openintro/simulated_scatter.csv"
-      (tc/dataset {:key-fn keyword})))
-
-(tc/head scatter)
+(rdatasets/openintro-simulated_scatter)
 
 ;; ## Plotly
 ;; We can also use datasets from [Plotly Sample Datasets](https://plotly.github.io/datasets/)
 
-(-> "https://raw.githubusercontent.com/plotly/datasets/refs/heads/master/1962_2006_walmart_store_openings.csv"
-    (tc/dataset {:key-fn keyword
-                 :parser-fn {:OPENDATE :string
-                             :date_super :string}})
-    (tc/head))
+(tc/dataset
+ "https://raw.githubusercontent.com/plotly/datasets/refs/heads/master/1962_2006_walmart_store_openings.csv"
+ {:key-fn keyword
+  :parser-fn {:OPENDATE :string
+              :date_super :string}})
 
 ;; ## tech.ml.dataset (TMD)
 ;; [TMD's repo](https://github.com/techascent/tech.ml.dataset/tree/master/test/data)
 ;; also has some datasets that we can use:
 
-(def stocks
-  (tc/dataset
-   "https://raw.githubusercontent.com/techascent/tech.ml.dataset/master/test/data/stocks.csv"
-   {:key-fn keyword}))
+(tc/dataset
+ "https://raw.githubusercontent.com/techascent/tech.ml.dataset/master/test/data/stocks.csv"
+ {:key-fn keyword})
 
-stocks

--- a/notebooks/noj_book/echarts.clj
+++ b/notebooks/noj_book/echarts.clj
@@ -8,7 +8,6 @@
 
 (ns noj-book.echarts
   (:require [tablecloth.api :as tc]
-            [noj-book.datasets]
             [fastmath.core :as fm]
             [fastmath.stats]
             [scicloj.kindly.v4.kind :as kind]))
@@ -288,12 +287,20 @@ data-for-waterfall
 ;; #### Dataset Preparation
 ;; Before we plot any line charts, it's helpful to prepare the dataset first.
 
+;; We will use the stocks dataset from the 
+;; [TMD's repo](https://github.com/techascent/tech.ml.dataset/tree/master/test/data).
+
+(defonce stocks
+  (tc/dataset
+   "https://raw.githubusercontent.com/techascent/tech.ml.dataset/master/test/data/stocks.csv"
+   {:key-fn keyword}))
+
 ;; This dataset originally contains three columns:
-(tc/head noj-book.datasets/stocks)
+(tc/head stocks)
 
 ;; To make it better serve this tutorial, let's widen it:
 (def reshaped-stocks
-  (-> noj-book.datasets/stocks
+  (-> stocks
       (tc/pivot->wider [:symbol] [:price] {:drop-missing? false})
       (tc/rename-columns keyword)))
 

--- a/notebooks/noj_book/echarts.clj
+++ b/notebooks/noj_book/echarts.clj
@@ -10,7 +10,8 @@
   (:require [tablecloth.api :as tc]
             [fastmath.core :as fm]
             [fastmath.stats]
-            [scicloj.kindly.v4.kind :as kind]))
+            [scicloj.kindly.v4.kind :as kind]
+            [scicloj.metamorph.ml.rdatasets :as rdatasets]))
 
 ;; ## Getting started
 
@@ -490,12 +491,12 @@ reshaped-stocks
 
 ;; Now, let's use a dataset to render more data onto the chart:
 
-(tc/row-count noj-book.datasets/scatter)
+(tc/row-count (rdatasets/openintro-simulated_scatter))
 
 (kind/echarts {:xAxis {}
                :yAxis {}
                :series [{:type :scatter
-                         :data (-> noj-book.datasets/scatter
+                         :data (-> (rdatasets/openintro-simulated_scatter)
                                    (tc/select-columns [:x :y])
                                    (tc/rows :as-vecs))}]})
 
@@ -594,14 +595,14 @@ reshaped-stocks
          tc/dataset)))
 
 ;; For example:
-(-> noj-book.datasets/iris
+(-> (rdatasets/datasets-iris)
     (correlations-dataset [:sepal-length :sepal-width :petal-length :petal-width]))
 
 ;; Visualizing a corrleation matrix as a heatmap:
 
 (let [columns-for-correlations [:sepal-length :sepal-width
                                 :petal-length :petal-width]
-      correlations (-> noj-book.datasets/iris
+      correlations (-> (rdatasets/datasets-iris)
                        (correlations-dataset columns-for-correlations)
                        (tc/select-columns [:coli :colj :corr-round])
                        tc/rows)]

--- a/notebooks/noj_book/tablecloth_table_processing.clj
+++ b/notebooks/noj_book/tablecloth_table_processing.clj
@@ -60,26 +60,26 @@
 
 ;; ## Setup
 
-;; We create a namespace and require the Tablecloth API namespaces:
-;; The main Dataset API [`tablecloth.api`](https://scicloj.github.io/tablecloth/#dataset-api)
-;; and the Column API [`tablecloth.column.api`](https://scicloj.github.io/tablecloth/#column-api) that we'll see below.
-;; We will also use [`tech.v3.dataset.print`](https://techascent.github.io/tech.ml.dataset/tech.v3.dataset.print.html) to control printing,
-;; `clojure.string` for some string processing,
-;; [Kindly](https://scicloj.github.io/kindly-noted/) to control
-;; the way certain things are displayed,
-;; [Clojure.Java-Time](https://github.com/dm3/clojure.java-time)
-;; for some time calculations, and the [`datetime`](https://cnuernber.github.io/dtype-next/tech.v3.datatype.datetime.html)
-;; namespace of dtype-next. 
+;; We create a namespace and require the following namespaces:
+
+;; * [`tablecloth.api`](https://scicloj.github.io/tablecloth/#dataset-api) - the main Tablecloth Dataset API 
+;; * [`tablecloth.column.api`](https://scicloj.github.io/tablecloth/#column-api) - the Tablecloth Column API 
+;; * [`tech.v3.dataset.print`](https://techascent.github.io/tech.ml.dataset/tech.v3.dataset.print.html) to control printing (from tech.ml.dataset)
+;; * `clojure.string` for string processing
+;; * `clojure.java.io` for file input/output
+;; * `scicloj.kindly.v4.kind` of the [Kindly](https://scicloj.github.io/kindly-noted/) standard to control the way certain values are displayed
+;; * `java-time.api` of [Clojure.Java-Time](https://github.com/dm3/clojure.java-time) for some time calculations
+;; * [`tech.v3.datatype.datetime`](https://cnuernber.github.io/dtype-next/tech.v3.datatype.datetime.html) of date and time operations (from dtype-next) 
 
 (ns noj-book.tablecloth-table-processing
   (:require [tablecloth.api :as tc]
             [tablecloth.column.api :as tcc]
             [tech.v3.dataset.print :as print]
             [clojure.string :as str]
+            [clojure.java.io :as io]
             [scicloj.kindly.v4.kind :as kind]
             [java-time.api :as java-time]
-            [tech.v3.datatype.datetime :as datetime]
-            [clojure.java.io :as io]))
+            [tech.v3.datatype.datetime :as datetime]))
 
 ;; ## Creating a dataset
 

--- a/notebooks/noj_book/tablecloth_table_processing.clj
+++ b/notebooks/noj_book/tablecloth_table_processing.clj
@@ -78,7 +78,8 @@
             [clojure.string :as str]
             [scicloj.kindly.v4.kind :as kind]
             [java-time.api :as java-time]
-            [tech.v3.datatype.datetime :as datetime]))
+            [tech.v3.datatype.datetime :as datetime]
+            [clojure.java.io :as io]))
 
 ;; ## Creating a dataset
 
@@ -340,32 +341,52 @@ some-trips
 
 ;; Datasets are often read from files.
 
-;; Let us read a file from the
+;; Let us read a file from the [Divvy Data](https://divvybikes.com/system-data), where the history of bike
+;; sharing trips in Chicago is shared publicly.
 ;; [Chicago bike trips](https://www.kaggle.com/datasets/godofoutcasts/cyclistic-bike-share-2023) dataset.
+
+;; Let us first download the data of one month.
+
+(def bike-trips-filename
+  "202304-divvy-tripdata.zip")
+
+(if (.exists (io/as-file bike-trips-filename))
+  [:already-downloaded bike-trips-filename]
+  (with-open [in (io/input-stream "https://divvy-tripdata.s3.amazonaws.com/202304-divvy-tripdata.zip")
+              out (io/output-stream bike-trips-filename)]
+    (io/copy in out)
+    [:just-downloaded bike-trips-filename]))
+
 ;; In this case, it is a [CSV](https://en.wikipedia.org/wiki/Comma-separated_values) file
-;; compressed by [gzip](https://en.wikipedia.org/wiki/Gzip), but other formats are supported as well.
+;; held inside a compressed [ZIP](https://en.wikipedia.org/wiki/ZIP_(file_format)) file,
+;; but other formats are supported as well.
 
 ;; First, let us read just a few rows:
 
-(->  "data/chicago-bikes/202304_divvy_tripdata.csv.gz"
+(-> bike-trips-filename 
+    tc/dataset
+    time)
+
+
+(->  bike-trips-filename
      (tc/dataset {:num-rows 3}))
 
 ;; So reading a dataset is easy, but sometimes we may wish to pass a few options
 ;; to handle it a bit better.
 
 ;; For example, you see that by default, the column names are strings:
-(->  "data/chicago-bikes/202304_divvy_tripdata.csv.gz"
+(->  bike-trips-filename
      (tc/dataset {:num-rows 9})
      tc/column-names)
 
 ;; We can apply the `keyword` function to all of them, to conveniently have keywords instead.
-(->  "data/chicago-bikes/202304_divvy_tripdata.csv.gz"
+(->  bike-trips-filename
      (tc/dataset {:num-rows 9
                   :key-fn keyword})
      tc/column-names)
 
 ;; Even better, we may process the names to replace underscores with dashes.
-(->  "data/chicago-bikes/202304_divvy_tripdata.csv.gz"
+(->  bike-trips-filename
      (tc/dataset {:num-rows 9
                   :key-fn (fn [s]
                             (-> s
@@ -374,7 +395,7 @@ some-trips
      tc/column-names)
 
 ;; Also, the date-time columns are parsed as strings.
-(->  "data/chicago-bikes/202304_divvy_tripdata.csv.gz"
+(->  bike-trips-filename
      (tc/dataset {:num-rows 9
                   :key-fn (fn [s]
                             (-> s
@@ -388,7 +409,7 @@ some-trips
 (def datetime-parser [:local-date-time
                       "yyyy-MM-dd HH:mm:ss"])
 
-(->  "data/chicago-bikes/202304_divvy_tripdata.csv.gz"
+(->  bike-trips-filename
      (tc/dataset {:num-rows 9
                   :key-fn (fn [s]
                             (-> s
@@ -408,7 +429,7 @@ some-trips
 ;; This practice is handy when reading big files.
 
 (defonce trips
-  (->  "data/chicago-bikes/202304_divvy_tripdata.csv.gz"
+  (->  bike-trips-filename
        (tc/dataset {:key-fn    (fn [s]
                                  (-> s
                                      (str/replace #"_" "-")

--- a/notebooks/noj_book/tableplot_datavis_intro.clj
+++ b/notebooks/noj_book/tableplot_datavis_intro.clj
@@ -23,8 +23,8 @@
 
 ;; ## Looking into the Iris Dataset
 
-;; First, let's look into the Iris dataset we have read
-;; [in the datasets chapter](./noj_book.datasets).
+;; First, let's look into the Iris dataset using the `scicloj.metamorph.ml.rdatasets` namespace,
+;; that allows us to fetch data from the [Rdatasets](https://vincentarelbundock.github.io/Rdatasets/articles/data.html) collection.
 
 (rdatasets/datasets-iris)
 

--- a/notebooks/noj_book/tableplot_datavis_intro.clj
+++ b/notebooks/noj_book/tableplot_datavis_intro.clj
@@ -8,7 +8,7 @@
   (:require [scicloj.tableplot.v1.plotly :as plotly]
             [tablecloth.api :as tc]
             [tablecloth.column.api :as tcc]
-            [noj-book.datasets :as datasets]))
+            [scicloj.metamorph.ml.rdatasets :as rdatasets]))
 
 ;; ## Introduction
 
@@ -26,7 +26,7 @@
 ;; First, let's look into the Iris dataset we have read
 ;; [in the datasets chapter](./noj_book.datasets).
 
-datasets/iris
+(rdatasets/datasets-iris)
 
 ;; The Iris dataset contains measurements for 150 iris flowers from three species (`setosa`, `versicolor`, `virginica`). The variables are:
 
@@ -40,7 +40,7 @@ datasets/iris
 
 ;; Let's start by creating a simple scatter plot to visualize the relationship between `sepal-length` and `sepal-width`.
 
-(-> datasets/iris
+(-> (rdatasets/datasets-iris)
     (plotly/layer-point
      {:=x :sepal-length
       :=y :sepal-width}))
@@ -51,7 +51,7 @@ datasets/iris
 
 ;; To distinguish between the different species, we can add color encoding based on the `species` column.
 
-(-> datasets/iris
+(-> (rdatasets/datasets-iris)
     (plotly/layer-point
      {:=x :sepal-length
       :=y :sepal-width
@@ -63,7 +63,7 @@ datasets/iris
 
 ;; Next, let's explore how petal measurements vary across species.
 
-(-> datasets/iris
+(-> (rdatasets/datasets-iris)
     (plotly/layer-point
      {:=x :petal-length
       :=y :petal-width
@@ -73,7 +73,7 @@ datasets/iris
 
 ;; ### Text plots
 ;; In certain cases, it might be useful to label the datapoints
-(-> datasets/iris
+(-> (rdatasets/datasets-iris)
     (tc/map-columns :species-short [:species] #(subs % 0 2))
     (plotly/layer-text
      {:=x :petal-length
@@ -84,7 +84,7 @@ datasets/iris
 
 ;; We can create a scatter plot matrix (SPLOM) to visualize the relationships between all pairs of variables.
 
-(-> datasets/iris
+(-> (rdatasets/datasets-iris)
     (plotly/splom
      {:=colnames [:sepal-length :sepal-width :petal-length :petal-width]
       :=color :species
@@ -97,7 +97,7 @@ datasets/iris
 
 ;; Let's create histograms to explore the distribution of `sepal-length`.
 
-(-> datasets/iris
+(-> (rdatasets/datasets-iris)
     (plotly/layer-histogram
      {:=x :sepal-length
       :=histnorm "count"
@@ -107,7 +107,7 @@ datasets/iris
 
 ;; To see how the distribution of `sepal-length` varies by species, we can add color encoding.
 
-(-> datasets/iris
+(-> (rdatasets/datasets-iris)
     (plotly/layer-histogram
      {:=x :sepal-length
       :=color :species
@@ -117,13 +117,13 @@ datasets/iris
 
 ;; ## Density Plots
 ;; Another way to visualize the distribution of a variable is with a density plot. These can also be colored by species.
-(-> datasets/iris
+(-> (rdatasets/datasets-iris)
     (plotly/layer-density
      {:=x :sepal-length
       :=color :species}))
 
 ;; ## Bar Charts
-(-> datasets/iris
+(-> (rdatasets/datasets-iris)
     (tc/group-by [:species])
     (tc/aggregate {:mean-width #(tcc/mean (:sepal-width %))})
     (plotly/layer-bar
@@ -134,7 +134,7 @@ datasets/iris
 
 ;; Box plots are useful for comparing distributions across categories.
 
-(-> datasets/iris
+(-> (rdatasets/datasets-iris)
     (plotly/layer-boxplot
      {:=y :sepal-length
       :=x :species}))
@@ -145,7 +145,7 @@ datasets/iris
 
 ;; Violin plots provide a richer representation of the distribution.
 
-(-> datasets/iris
+(-> (rdatasets/datasets-iris)
     (plotly/layer-violin
      {:=y :sepal-length
       :=x :species
@@ -156,7 +156,7 @@ datasets/iris
 
 ;; We can add a smoothing layer to show trend lines in the data.
 
-(-> datasets/iris
+(-> (rdatasets/datasets-iris)
     (plotly/base
      {:=x :sepal-length
       :=y :sepal-width
@@ -172,7 +172,7 @@ datasets/iris
 
 ;; ### Changing Marker Sizes
 
-(-> datasets/iris
+(-> (rdatasets/datasets-iris)
     (plotly/layer-point
      {:=x :sepal-length
       :=y :sepal-width
@@ -182,7 +182,7 @@ datasets/iris
 
 ;; ### Changing Marker Color (for all marks)
 
-(-> datasets/iris
+(-> (rdatasets/datasets-iris)
     (plotly/layer-point
      {:=x :sepal-length
       :=y :sepal-width
@@ -192,7 +192,7 @@ datasets/iris
 
 ;; ### Adjusting Opacity
 
-(-> datasets/iris
+(-> (rdatasets/datasets-iris)
     (plotly/layer-point
      {:=x :sepal-length
       :=y :sepal-width
@@ -202,7 +202,7 @@ datasets/iris
 
 ;; ### Changing axis titles
 ;; If you desire different axis titles than the variable names, those can be changed as well: 
-(-> datasets/iris
+(-> (rdatasets/datasets-iris)
     (plotly/layer-point
      {:=x :sepal-length
       :=y :sepal-width
@@ -216,7 +216,7 @@ datasets/iris
 
 ;; We can create a 3d scatter plot to visualize relationships in three dimensions.
 
-(-> datasets/iris
+(-> (rdatasets/datasets-iris)
     (plotly/layer-point
      {:=x :sepal-length
       :=y :sepal-width


### PR DESCRIPTION
@behrica 
Following your comments in Zulip ([#**kindly-dev>copy/paste from "books"**](https://clojurians.zulipchat.com/#narrow/channel/454856-kindly-dev/topic/copy.2Fpaste.20from.20.22books.22)), this draft PR makes a few chapters copy-paste friendly by removing their depdendency on local files or other namespaces.

~~Note it relies on a git dependency of metamorph.ml with the recent `rdatasets` imrovements. I propose we merge this PR after the next release of metamorph.ml.~~ (edit: now it uses the new metamorph.ml release)

There are still a couple of chapters that rely on local files: `linear_regression_intro` and `fastmath_vector_word_embeddings`.  I should see whether their data files can be fetched easily and quickly.