### PR TITLE
in the "make docs" github action, remove the intermediate qmd files 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,10 @@ jobs:
            
     - name: fix permisions
       run:  sudo chmod o+w docs/
-          
+
+    - name: cleanup intermediate qmd files
+      run:  sudo rm docs/*.qmd
+      
     - name: Setup Pages
       uses: actions/configure-pages@v5
     - name: Build with Jekyll


### PR DESCRIPTION
…so that Jekyll will not try to handle them unnecessarily (and bugilly)