### PR TITLE
make two jars

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,11 @@ jobs:
             cli: 1.12.0.1495
 
        - name: create clojupyter kernel
-         run: clojure -T:build create-uber
+         run: clj -T:build create-uber-clojupyter
+
+       - name: create clay kernel kernel
+         run: clj -T:build create-uber-clay
+  
 
              
        - name: Release


### PR DESCRIPTION
create two uberjars with seperate capabilities:

- being a clojupyter kernel (and not having clay)
- launching clay in uberjar start, and not having clojupyter